### PR TITLE
LegacyKeyValueFormat: "ENV key=value" should be used instead of legac…

### DIFF
--- a/Dockerfile.almalinux8
+++ b/Dockerfile.almalinux8
@@ -1,5 +1,5 @@
 FROM almalinux:8
-ENV HOME /
+ENV HOME=/
 RUN dnf update -y
 RUN dnf install -y \
         rpm-build \

--- a/Dockerfile.almalinux9
+++ b/Dockerfile.almalinux9
@@ -1,5 +1,5 @@
 FROM almalinux:9
-ENV HOME /
+ENV HOME=/
 RUN dnf update -y
 RUN dnf install -y \
         rpm-build \

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -1,5 +1,5 @@
 FROM amazonlinux:2
-ENV HOME /
+ENV HOME=/
 RUN yum update -y
 RUN yum install -y \
         rpm-build \

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -1,5 +1,5 @@
 FROM amazonlinux:2023
-ENV HOME /
+ENV HOME=/
 RUN dnf update -y
 RUN dnf install -y \
         systemd \

--- a/Dockerfile.rockylinux8
+++ b/Dockerfile.rockylinux8
@@ -1,5 +1,5 @@
 FROM rockylinux:8
-ENV HOME /
+ENV HOME=/
 RUN dnf update -y
 RUN dnf install -y \
         systemd \

--- a/Dockerfile.rockylinux9
+++ b/Dockerfile.rockylinux9
@@ -1,5 +1,5 @@
 FROM rockylinux:9
-ENV HOME /
+ENV HOME=/
 RUN dnf update -y
 RUN dnf install -y \
         systemd \


### PR DESCRIPTION
…y "ENV key value" format (line 2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment variable syntax for `HOME` in Dockerfiles across multiple Linux distributions (AlmaLinux 8 & 9, Amazon Linux 2 & 2023, Rocky Linux 8 & 9)
	- Standardized `ENV HOME` declaration from `ENV HOME /` to `ENV HOME=/`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->